### PR TITLE
Two enhancements (see description)

### DIFF
--- a/AutoHotkey.ahk
+++ b/AutoHotkey.ahk
@@ -42,17 +42,21 @@ Elevate(Params)
 DeHashBang(FilePath)
 {
 	FileRead, Script, %FilePath%
-	if RegExMatch(Script, "`a)^\s*`;#!\s*(.+)", Match)
+	if RegExMatch(Script, "`a)^\s*`;\s*#!\s*(.+)", Match)
 	{
 		AhkPath := Trim(Match1)
-		Vars := {"%A_ScriptDir%": FilePath "\.."
-		, "%A_WorkingDir%": A_WorkingDir
-		, "%A_AppData%": A_AppData
-		, "%A_AppDataCommon%": A_AppDataCommon
-		, "%A_LineFile%": FilePath
-		, "%A_AhkPath%": A_AhkPath}
-		for SearchText, Replacement in Vars
-			StringReplace, AhkPath, AhkPath, %SearchText%, %Replacement%, All
+		if (!InStr(AhkPath, "\")){
+			AhkPath := A_AhkPath "\..\" AhkPath
+		} else {
+			Vars := {"%A_ScriptDir%": FilePath "\.."
+			, "%A_WorkingDir%": A_WorkingDir
+			, "%A_AppData%": A_AppData
+			, "%A_AppDataCommon%": A_AppDataCommon
+			, "%A_LineFile%": FilePath
+			, "%A_AhkPath%": A_AhkPath}
+			for SearchText, Replacement in Vars
+				StringReplace, AhkPath, AhkPath, %SearchText%, %Replacement%, All
+		}
 		return AhkPath
 	}
 	return A_AhkPath


### PR DESCRIPTION
Allow whitespace between ; and #

If hashbang path does not contain a \ symbol, prepend the AHK path, thus
allowing short hashbangs to EXEs in the AHK folder
